### PR TITLE
feat: Add function to manually configure available amounts

### DIFF
--- a/network-owned-liquidity/README.md
+++ b/network-owned-liquidity/README.md
@@ -39,7 +39,7 @@ LiquidityOrder {
 
 ```java
 /**
- * Configures a new liquidity order
+ * Configures a liquidity order
  *
  * @param pid The poolId on the balanced dex
  * @param limit The max ICX limit to purchase for each Order Period
@@ -49,12 +49,29 @@ public void configureOrder(BigInteger pid, BigInteger limit) {
     OnlyICONGovernance()
     order = LiquidityOrder {
         limit = limit,
-        remaining = limit,
+        remaining = 0,
         lastPurchaseBlock = Context.getBlockHeight()
     }
 
     orders.set(pid, order);
 }
+```
+
+```java
+    /**
+     * Configures the remaining amount of a liquidity order.
+     *
+     * @param pid   The poolId on the balanced dex
+     * @param amount The amount to make available for purchase, max limited by the order limit.
+     */
+
+    @External
+    public void setAvailableAmount(BigInteger pid, BigInteger amount) {
+        OnlyICONGovernance();
+        order = orders.get(pid);
+        order.remaining = amount;
+        orders.set(pid, order);
+    }
 ```
 
 ```java

--- a/network-owned-liquidity/src/main/java/icon/inflation/score/nol/NetworkOwnedLiquidity.java
+++ b/network-owned-liquidity/src/main/java/icon/inflation/score/nol/NetworkOwnedLiquidity.java
@@ -143,14 +143,20 @@ public class NetworkOwnedLiquidity implements INetworkOwnedLiquidity {
     @External
     public void configureOrder(BigInteger pid, BigInteger limit) {
         onlyOwner();
-        LiquidityOrder order = new LiquidityOrder();
+        LiquidityOrder order = orders.getOrDefault(pid, new LiquidityOrder());
         order.limit = limit;
-        order.lastPurchaseBlock = BigInteger.valueOf(Context.getBlockHeight());;
-        order.remaining = limit;
         orders.set(pid, order);
         if (!DBUtils.arrayDbContains(ordersList, pid)) {
             ordersList.add(pid);
         }
+    }
+
+    @External
+    public void setAvailableAmount(BigInteger pid, BigInteger amount) {
+        onlyOwner();
+        LiquidityOrder order = orders.get(pid);
+        order.remaining = amount;
+        orders.set(pid, order);
     }
 
     @External

--- a/network-owned-liquidity/src/main/java/icon/inflation/score/nol/NetworkOwnedLiquidity.java
+++ b/network-owned-liquidity/src/main/java/icon/inflation/score/nol/NetworkOwnedLiquidity.java
@@ -46,13 +46,15 @@ public class NetworkOwnedLiquidity implements INetworkOwnedLiquidity {
     public static final BigInteger DEFAULT_SWAP_REWARDS = BigInteger.valueOf(100); // 1%
     public static final BigInteger DEFAULT_LP_SLIPPAGE = BigInteger.valueOf(100); // 1%
 
-    public NetworkOwnedLiquidity(Address _balancedDex, Address _balancedOracle) {
-        balancedDex.set(_balancedDex);
-        balancedOracle.set(_balancedOracle);
+    public NetworkOwnedLiquidity(@Optional Address _balancedDex, @Optional Address _balancedOracle) {
+        if (balancedDex.get() == null) {
+            balancedDex.set(_balancedDex);
+            balancedOracle.set(_balancedOracle);
 
-        orderPeriod.set(DEFAULT_ORDER_PERIOD);
-        swapReward.set(DEFAULT_SWAP_REWARDS);
-        lPSlippage.set(DEFAULT_LP_SLIPPAGE);
+            orderPeriod.set(DEFAULT_ORDER_PERIOD);
+            swapReward.set(DEFAULT_SWAP_REWARDS);
+            lPSlippage.set(DEFAULT_LP_SLIPPAGE);
+        }
     }
 
     @EventLog(indexed = 1)

--- a/network-owned-liquidity/src/test/java/icon/inflation/score/nol/NetworkOwnedLiquidityTest.java
+++ b/network-owned-liquidity/src/test/java/icon/inflation/score/nol/NetworkOwnedLiquidityTest.java
@@ -72,12 +72,12 @@ public class NetworkOwnedLiquidityTest extends TestBase {
         assertEquals(pid1, orders[0].pid);
         assertEquals(limit1, orders[0].limit);
         assertEquals(getCurrentBlock().subtract(BigInteger.ONE), orders[0].lastPurchaseBlock);
-        assertEquals(limit1, orders[0].remaining);
+        assertEquals(BigInteger.ZERO, orders[0].remaining);
 
         assertEquals(pid2, orders[1].pid);
         assertEquals(limit2, orders[1].limit);
         assertEquals(getCurrentBlock(), orders[1].lastPurchaseBlock);
-        assertEquals(limit2, orders[1].remaining);
+        assertEquals(BigInteger.ZERO, orders[1].remaining);
     }
 
     @Test
@@ -98,8 +98,8 @@ public class NetworkOwnedLiquidityTest extends TestBase {
 
         assertEquals(pid1, orders[0].pid);
         assertEquals(limit2, orders[0].limit);
-        assertEquals(getCurrentBlock(), orders[0].lastPurchaseBlock);
-        assertEquals(limit2, orders[0].remaining);
+        assertEquals(getCurrentBlock().subtract(BigInteger.ONE), orders[0].lastPurchaseBlock);
+        assertEquals(BigInteger.ZERO, orders[0].remaining);
     }
 
     @Test
@@ -123,7 +123,7 @@ public class NetworkOwnedLiquidityTest extends TestBase {
         assertEquals(pid2, orders[0].pid);
         assertEquals(limit2, orders[0].limit);
         assertEquals(getCurrentBlock().subtract(BigInteger.ONE), orders[0].lastPurchaseBlock);
-        assertEquals(limit2, orders[0].remaining);
+        assertEquals(BigInteger.ZERO, orders[0].remaining);
     }
 
     @Test
@@ -134,6 +134,7 @@ public class NetworkOwnedLiquidityTest extends TestBase {
         BigInteger amount = BigInteger.TEN.multiply(EXA);
         BigInteger pid = BigInteger.ONE;
         networkOwnedLiquidity.invoke(governance, "configureOrder", pid, BigInteger.valueOf(100000).multiply(EXA));
+        sm.getBlock().increase(NetworkOwnedLiquidity.DEFAULT_ORDER_PERIOD.longValue());
 
         Address baseToken = sICX.getAddress();
         Address quoteToken = bnUSD.getAddress();
@@ -198,6 +199,8 @@ public class NetworkOwnedLiquidityTest extends TestBase {
         BigInteger pid2 = BigInteger.TWO;
         networkOwnedLiquidity.invoke(governance, "configureOrder", pid1, EXA.multiply(EXA));
         networkOwnedLiquidity.invoke(governance, "configureOrder", pid2, EXA.multiply(EXA));
+        networkOwnedLiquidity.invoke(governance, "setAvailableAmount", pid1, EXA.multiply(EXA));
+        networkOwnedLiquidity.invoke(governance, "setAvailableAmount", pid2, EXA.multiply(EXA));
 
         Address baseToken1 = sICX.getAddress();
         Address baseToken2 = sARCH.getAddress();
@@ -278,6 +281,7 @@ public class NetworkOwnedLiquidityTest extends TestBase {
         BigInteger amount = BigInteger.TEN.multiply(EXA);
         BigInteger pid = BigInteger.ONE;
         networkOwnedLiquidity.invoke(governance, "configureOrder", pid, EXA.multiply(EXA));
+        networkOwnedLiquidity.invoke(governance, "setAvailableAmount", pid, EXA.multiply(EXA));
 
         Address baseToken = sICX.getAddress();
         Address quoteToken = bnUSD.getAddress();
@@ -356,6 +360,7 @@ public class NetworkOwnedLiquidityTest extends TestBase {
         BigInteger expectedRewards = expectedUSDRewards.multiply(EXA).divide(ICXPriceInUSD);
         networkOwnedLiquidity.getAccount().addBalance(expectedRewards.multiply(BigInteger.valueOf(3)));
         networkOwnedLiquidity.invoke(governance, "configureOrder", pid, expectedRewards.multiply(BigInteger.TWO));
+        networkOwnedLiquidity.invoke(governance, "setAvailableAmount", pid, expectedRewards.multiply(BigInteger.TWO));
 
         // Act
         networkOwnedLiquidity.invoke(dex.account, "onIRC31Received", user.getAddress(), user.getAddress(), pid, amount,
@@ -389,6 +394,7 @@ public class NetworkOwnedLiquidityTest extends TestBase {
         BigInteger amount = BigInteger.TEN.multiply(EXA);
         BigInteger pid = BigInteger.ONE;
         networkOwnedLiquidity.invoke(governance, "configureOrder", pid, EXA.multiply(EXA));
+        networkOwnedLiquidity.invoke(governance, "setAvailableAmount", pid, EXA.multiply(EXA));
 
         Address baseToken = sICX.getAddress();
         Address quoteToken = bnUSD.getAddress();
@@ -442,6 +448,7 @@ public class NetworkOwnedLiquidityTest extends TestBase {
         BigInteger amount = BigInteger.TEN.multiply(EXA);
         BigInteger pid = BigInteger.ONE;
         networkOwnedLiquidity.invoke(governance, "configureOrder", pid, EXA.multiply(EXA));
+        networkOwnedLiquidity.invoke(governance, "setAvailableAmount", pid, EXA.multiply(EXA));
 
         Address baseToken = sARCH.getAddress();
         Address quoteToken = sICX.getAddress();
@@ -500,6 +507,7 @@ public class NetworkOwnedLiquidityTest extends TestBase {
         BigInteger amount = BigInteger.TEN.multiply(EXA);
         BigInteger pid = BigInteger.ONE;
         networkOwnedLiquidity.invoke(governance, "configureOrder", pid, EXA.multiply(EXA));
+        networkOwnedLiquidity.invoke(governance, "setAvailableAmount", pid, EXA.multiply(EXA));
 
         Address baseToken = sICX.getAddress();
         Address quoteToken = bnUSD.getAddress();

--- a/score-lib/src/main/java/icon/inflation/score/interfaces/INetworkOwnedLiquidity.java
+++ b/score-lib/src/main/java/icon/inflation/score/interfaces/INetworkOwnedLiquidity.java
@@ -52,13 +52,23 @@ public interface INetworkOwnedLiquidity {
     BigInteger getInvestedEmissions();
 
     /**
-     * Configures a new liquidity order
+     * Configures a liquidity order
      *
      * @param pid   The poolId on the balanced dex
      * @param limit The max USD limit to purchase for each Order Period
      */
     @External
     void configureOrder(BigInteger pid, BigInteger limit);
+
+
+    /**
+     * Configures the remaining amount of a liquidity order
+     *
+     * @param pid   The poolId on the balanced dex
+     * @param amount The amount to make available for purchase, max limited by the order limit.
+     */
+    @External
+    void setAvailableAmount(BigInteger pid, BigInteger amount);
 
     /**
      * Removes a liquidity order

--- a/score-lib/src/main/java/icon/inflation/score/structs/LiquidityOrder.java
+++ b/score-lib/src/main/java/icon/inflation/score/structs/LiquidityOrder.java
@@ -2,6 +2,7 @@ package icon.inflation.score.structs;
 
 import score.ObjectReader;
 import score.ObjectWriter;
+import score.Context;
 
 import java.math.BigInteger;
 
@@ -11,6 +12,11 @@ public class LiquidityOrder {
     public BigInteger remaining;
     // return value only
     public BigInteger pid;
+
+    public LiquidityOrder() {
+        lastPurchaseBlock = BigInteger.valueOf(Context.getBlockHeight());
+        remaining = BigInteger.ZERO;
+    }
 
     public static void writeObject(ObjectWriter writer, LiquidityOrder liquidityOrder) {
         liquidityOrder.writeObject(writer);


### PR DESCRIPTION
New orders will defult to 0 and current order will keep their current amount, configuring a order should now only affect the rate in which it gains more availbable for purschase